### PR TITLE
fix(table): escape html entities

### DIFF
--- a/templates/table.twig
+++ b/templates/table.twig
@@ -57,13 +57,18 @@ $(document).ready(function() {
     let serverTotal = null;
 
     const htmlInjectionMap = new Map();
+    function decodeHtml(html) {
+        const txt = document.createElement("textarea");
+        txt.innerHTML = html;
+        return txt.value;
+    }
     const renderRawHTML = (htmlString) => {
         if (typeof htmlString === 'string' && /<[^>]*>/.test(htmlString)) {
             const marker = `__HTML_CONTENT_${Math.random().toString(36).substr(2, 9)}__`;
             htmlInjectionMap.set(marker, htmlString);
             return marker;
         }
-        return htmlString;
+        return decodeHtml(htmlString);
     };
 
     const flexRender = (comp, props) => (typeof comp === 'function' ? comp(props) : comp);

--- a/templates/table.twig
+++ b/templates/table.twig
@@ -413,7 +413,7 @@ $(document).ready(function() {
 
     const renderTableElement = () => {
         return html`
-            <div class="fixed-table-container">
+            <div class="fixed-table-container" style="overflow-x: scroll;">
                 <table class="table table-striped table-bordered table-hover">
                     <thead>
                         ${table.getHeaderGroups().map(headerGroup => html`


### PR DESCRIPTION
Some strings in tables would render with HTML entities displayed, they are now escaped.